### PR TITLE
don't blindly jump releases

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,8 +12,20 @@
 # From: Rick van Rein <rick@openfortress.nl>
 
 
-# ARPA2 base image is the moving target Debian Stable
-FROM debian:stable
+# ARPA2 base image is the latest Debian Stable that we have tested and is known
+# to fully work with all demos.
+#
+# As soon as a new release of Debian Stable comes out, please test and
+# coordinate this with the owners of the different demos so that we can plan an
+# upgrade moment of our own choosing without being strictly dictated by the release
+# schedule of Debian and the inevitable period of non-working demos right after
+# a new Debian release.
+#
+# From a security point of view: a new stable is released every two years and
+# each stable gets security patches for the most popular packages for five years
+# so that would give us plenty of time to keep tracking stable without ever
+# breaking our demos.
+FROM debian:stretch
 
 # Install required packages
 RUN \


### PR DESCRIPTION
I propose to stop tracking the moving target Debian Stable because this renders a lot of demos broken at the time Debian releases a new stable. A situation that can last for months depending on the schedule and availability of the developer of a particular demo. During this time the demo can no longer be showed to or used by third parties that might be interested in the project.

Instead, track the latest stable that is known to work and as soon as Debian releases a new stable test all demos with it and coordinate this with the individual owners of each demo before bumping the base image.

For now track Debian Stretch because that is the latest stable that is known to work and thus supported by all of us. Since Buster has been released this summer, work should be initiated to make sure all demos work with Buster so that we can move the base image to it.

Maybe we can create an extra image during the transition to the new stable so that we can all test and sort of flag when our own demos are ready. Maybe call it "nextbase"? I'm not sure how much work an extra image like this would be in the current infrastructure.