### PR TITLE
Reservoir drops Riak KV

### DIFF
--- a/demo-reservoir/Dockerfile
+++ b/demo-reservoir/Dockerfile
@@ -71,18 +71,16 @@ RUN chmod go+r /etc/krb5.keytab
 COPY --from=reservoir /var/arpa2/reservoir /var/arpa2/reservoir
 
 
-# Install operator's shells to play around with the Reservoir
+# Install utitilities commonly used in the demo environments
 #
-
-COPY arpa2reservoir.py /usr/local/lib/python2.7/dist-packages/arpa2reservoir.py
-#PY3# COPY arpa2reservoir.py /usr/local/lib/python3/dist-packages/arpa2reservoir.py
-RUN ln -s /usr/local/lib/python2.7/dist-packages/arpa2reservoir.py /usr/bin/arpa2reservoir
-#PY3# RUN ln -s /usr/local/lib/python3/dist-packages/arpa2reservoir.py /usr/bin/arpa2reservoir
-COPY arpa2acl.py /usr/local/lib/python2.7/dist-packages/arpa2acl.py
-RUN ln -s /usr/local/lib/python2.7/dist-packages/arpa2acl.py /usr/bin/arpa2acl
-RUN chmod ugo+x /usr/bin/arpa2reservoir /usr/bin/arpa2acl
 COPY arpa2gnu /usr/bin/arpa2gnu
 COPY arpa2kinit /usr/bin/arpa2kinit
+
+
+# Install the arpa2shell utilities from Git
+#
+RUN git clone https://github.com/arpa2/arpa2shell /usr/local/src/arpa2shell.git
+RUN python /usr/local/src/arpa2shell.git/setup.py install
 
 
 # Install the main script for the Reservoir service

--- a/demo-reservoir/Dockerfile
+++ b/demo-reservoir/Dockerfile
@@ -18,89 +18,13 @@
 #PIP2EASYINSTALL# RUN pip install python-ldap riak six
 
 
-### Prepare: Build Riak KV from source
-#
-# Riak KV may not be maintained any longer; its binaries
-# have not been updated since November 2017 and are now
-# lagging behind Debian Stable.  Its source code has had
-# a preview on 2.2.4 ever since that same period, but it
-# has not been put forward.  It looks like development
-# has come to a sudden stop.  Building from source also
-# reveals cracks, namely incompatibility with Erlang as
-# distributed nowadays in Debian Stable, causing
-#
-### ERROR: OTP release 19 does not match required regex R16|17
-### ERROR: compile failed while processing /usr/local/src/riak-riak-2.2.3/deps/node_package: rebar_abort
-#
-# This is why binaries for Riak KV and libssl1.0.0 have
-# been included.  We should monitor Riak KV because it
-# may be an upcoming problem.  There are more kinds of
-# object store, so there is no cause for panic.  New
-# installations (not this mere demo) may wonder what to
-# do before sending customer objects to their store.
-#
-# Note that tiot.jp references newer Riak KV versions,
-# https://files.tiot.jp/riak/kv/2.2/2.2.6/
-# No idea who they are; found them only on IRC at
-# freenode.net #riak -- so doubtful as a source.
+### Prepare: Reservoir Demonstration Files
 
-# FROM arpa2/build-bin AS bin
-# 
-# RUN apt-get install -y erlang
-# 
-# ADD https://github.com/basho/riak/archive/riak-2.2.3.tar.gz /root/riak-2.2.3.tar.gz
-# 
-# RUN cd /usr/local/src ; tar -xzvf /root/riak-2.2.3.tar.gz
-# RUN cd /usr/local/src/riak-riak-2.2.3 ; make rel install
+FROM arpa2/files-reservoir AS reservoir
 
 
-### Prepare: Riak KV
-#
-# First, a preparation for Reservoir: installing Riak KV.
-#
-# The instructions for doing this are of the "wget | su" type,
-# which isn't generally acceptable.
-#
-# We therefore run the necessary steps in a build image, and
-# copy Riak KV from there.
 
-
-#BELOW# FROM arpa2/base AS riakkv
-
-#
-# Option 1. Setting up an instable environment
-#
-
-# RUN apt-get update && apt-get -y upgrade
-# RUN apt-get install --no-install-recommends -y \
-# 	gnupg apt-transport-https
-# 
-# COPY basho-distro.asc /root
-# COPY basho-sources.list /etc/apt/sources.list.d/basho-sources.list
-# 
-# RUN apt-key add /root/basho-distro.asc &>/dev/null
-# 
-# RUN apt-get update && apt-get -y upgrade
-# 
-# RUN DEBIAN_FRONTEND=noninteractive \
-# 	apt-get install --no-install-recommends -y \
-# 	riak
-
-#
-# Option 2. Install from dpkg
-#
-
-#BELOW# RUN apt-get update && apt-get -y upgrade
-#BELOW# RUN apt-get install --no-install-recommends -y \
-#BELOW# 	openssl logrotate sudo
-#BELOW# 
-#BELOW# COPY riak_2.2.3-1_amd64.deb /root
-#BELOW# RUN dpkg -i --force-depends /root/riak_*_amd64.deb || /bin/true
-
-#BELOW# CMD [ "/bin/bash" ]
-
-
-### Setup: Riak KV (.deb), OpenLDAP
+### Setup: OpenLDAP
 #
 #
 
@@ -109,19 +33,12 @@
 FROM arpa2/build-bin
 
 
-# Install Riak KV from .deb (moved from option 2 above)
-#
-
-# Install libssl1.0.0 old-school dependency from binary
-#TRY_TIOT_JP# COPY libssl1.0.0_*_amd64.deb /root
-#TRY_TIOT_JP# RUN dpkg -i /root/libssl1.0.0_1.0.1t-1+deb7u4_amd64.deb
-
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get install --no-install-recommends -y \
 	openssl logrotate sudo libncurses5 libtinfo5 \
 	python3-dev
 
-RUN python3 -m easy_install python3-ldap riak six web2ldap
+RUN python3 -m easy_install python3-ldap six web2ldap
 
 #TODO:BUILD# RUN cd /usr/local/src ; git clone https://github.com/arpa2/arpa2shell-cmdparser cmdparser.git
 #TODO:BUILD# RUN cd /usr/local/src/cmdparser.git/cmdparser ; python setup.py install
@@ -136,6 +53,7 @@ RUN DEBIAN_FRONTEND=noninteractive SLAPD_PASSWORD=sekreet \
 	slapd libsasl2-modules-gssapi-mit
 
 COPY initial.ldif /root/initial.ldif
+# COPY index.ldif   /root/index.ldif
 COPY webdav-reservoir/schema/* /etc/ldap/schema/
 RUN rm -rf /etc/ldap/slapd.d
 COPY slapd.conf /etc/ldap/slapd.conf
@@ -148,22 +66,9 @@ RUN chmod go+r /etc/krb5.keytab
 #RATHER #RUN chown opldap:openldap /etc/ldap/slapd.keytab
 
 
-# Install Riak KV -- which is really quite broken in terms of dependencies :'-(
+# Copy files-reservoir into /var/arpa2/reservoir
 #
-
-#TRY_TIOT_JP# COPY riak_*_amd64.deb /root
-#TRY_TIOT_JP# RUN ( dpkg -i --force-depends /root/riak_*_amd64.deb || /bin/true )
-
-# ADD https://files.tiot.jp/riak/kv/2.2/2.2.6/debian/9/riak_2.2.6-1_amd64.deb /root/riak_2.2.6-1_amd64.deb
-# RUN dpkg -i /root/riak_2.2.6-1_amd64.deb
-
-ADD https://files-source.tiot.jp/riak/kv/2.9/2.9.0p4/debian/9/riak_2.9.0p4-1_amd64.deb /root/riak_2.9.0p4-1_amd64.deb
-RUN dpkg --force-depends -i /root/riak_2.9.0p4-1_amd64.deb
-
-#SATISFIED-DEPENDENCY# # Upgrade Riak KV dependency on libssl1.0.0 to Debian Stable libssl1.0.2l+
-#SATISFIED-DEPENDENCY# RUN grep libssl1.0.0 /var/lib/dpkg/status
-#SATISFIED-DEPENDENCY# RUN sed -i -e 's+libssl1\.0\.0 (>= 1\.0\.0)+libssl1.0.2 (>= 1.0.2l)+' /var/lib/dpkg/status
-#SATISFIED-DEPENDENCY# #WILLNOWFAIL!# RUN grep libssl1.0.0 /var/lib/dpkg/status
+COPY --from=reservoir /var/arpa2/reservoir /var/arpa2/reservoir
 
 
 # Install operator's shells to play around with the Reservoir
@@ -178,16 +83,6 @@ RUN ln -s /usr/local/lib/python2.7/dist-packages/arpa2acl.py /usr/bin/arpa2acl
 RUN chmod ugo+x /usr/bin/arpa2reservoir /usr/bin/arpa2acl
 COPY arpa2gnu /usr/bin/arpa2gnu
 COPY arpa2kinit /usr/bin/arpa2kinit
-
-
-# Install some Python extras
-#
-
-# COPY py/lib/python2.7/site-packages/ /usr/lib/python2.7/dist-packages/
-# COPY py/lib/python2.7/site-packages/ /site-packages/
-
-#PIP2EASYINSTALL# COPY --from=pip /usr/local/lib/python2.7/dist-packages/ /usr/local/lib/python2.7/dist-packages
-#PIP2EASYINSTALL# COPY --from=pip       /usr/lib/python2.7/dist-packages/       /usr/lib/python2.7/dist-packages
 
 
 # Install the main script for the Reservoir service

--- a/demo-reservoir/README.MD
+++ b/demo-reservoir/README.MD
@@ -1,4 +1,4 @@
-# README for Docker Image arpa2/reservoir
+# README for Docker Image arpa2/demo-reservoir
 
 > *This is a simple, initial version of the ARPA2 Reservoir
 > as designed in the InternetWide.org project, and implemented
@@ -122,6 +122,34 @@ of the tree, to help with situations where not all
 domains have the same service, where subdomains have
 additional service, where customers take out only one
 but not both the services, and so on.
+
+## Use the prepared Reservoir Domain
+
+The music collection from the `arpa2/files-reservoir` Docker Demo are loaded
+in `/var/arpa2/reservoir` and the shell `arpa2reservoir` uses those as
+file store, with metadata in LDAP.  The additional links and a few
+descriptive files from the demo are ignored.
+
+The following commands can now be tried to start at the
+default collection for domain `arpa2.org`, then follow
+index links, first `Negrin` then `Whispering`, and list
+resources.
+
+```
+index domain arpa2.org
+index path Negrin Whispering
+resource list
+resource get efd7a299-2b35-457d-83af-25fd54697e99
+```
+
+The latter dumps a file on standard output, which we should
+improve on, but in this case it is a simple text file, so no
+harm done.  Negrin has a habit of using Creative Commons
+licenses, yet deliver interesting guitar music with classical
+inspirational links.  Enjoy!
+
+
+## Setup your own Reservoir Domain
 
 Once on an `arpa2reservoir` shell, you can do things like
 adding domains, Resource Collections underneath domains,

--- a/demo-reservoir/TODO
+++ b/demo-reservoir/TODO
@@ -7,6 +7,7 @@
 + construct an image arpa2/buildphase-pip FROM debian:stable with "just" pip
 + use it to RUN pip install cmdparser python-ldap riak
 + COPY --from /usr/*/lib/python2.7/dist-utils/ /usr/*/lib/python2.7/dist-utils
-- Somehow get riak to create bucket types with or without crypto:md5 facility
+X Somehow get riak to create bucket types with or without crypto:md5 facility
 + Drop user_pasw.py from Dockerfile [also in the arpa2/identityhub target]
-
++ Make arpa2reservoir work; riak->files, str.strip, imports
+- Expand arpa2acl with libarpa2common wrapper

--- a/demo-reservoir/ldap.conf
+++ b/demo-reservoir/ldap.conf
@@ -17,7 +17,7 @@ URI  ldapi://%2ftmp%2fldap-socket ldap://reservoir.arpa2:1389/
 # conceptually simpler to split views as they tend to be
 # more distributed and single-minded than a server.
 #
-BASE ou=Reservoir,o=internetwide.org,OU=ARPA2
+BASE ou=Reservoir,o=arpa2.net,ou=InternetWide
 
 #
 # There are two BINDDN setup below:

--- a/demo-reservoir/reservoir.sh
+++ b/demo-reservoir/reservoir.sh
@@ -12,10 +12,7 @@ sed -e '$,$s/^\([^ \t]*\)[ \t]/\1 reservoir.arpa2 /' < /etc/hosts > /etc/hosts2 
 echo Configuring OpenLDAP
 echo
 slapadd -c -f /etc/ldap/slapd.conf -l /root/initial.ldif
-
-echo Start Riak KV
-echo
-riak start
+slapadd -c -f /etc/ldap/slapd.conf -l /var/arpa2/reservoir/index.ldif
 
 #NOTHERE# echo 'Starting web2ldap (only over IPv4) on port 1761...'
 #NOTHERE# echo


### PR DESCRIPTION
The Riak KV system was [removed from arpa2reservoir](https://github.com/arpa2/arpa2shell/commit/a818e4c402e00ce6424dddf04ff33e3a8c5ef33e) in the [arpa2shell](https://github.com/arpa2/arpa2shell) package.  This update has now been incorporated into this demonstration.  A new Docker Demo will be built and should soon be available as a binary for use with `docker pull arpa2/demo-reservoir`.